### PR TITLE
fix: remove non-null assertion from priseList in GraphQL schema

### DIFF
--- a/back/schemas/prise.graphql
+++ b/back/schemas/prise.graphql
@@ -8,7 +8,7 @@ type Prise {
 
 extend type Query {
   prise(id: ID!): Prise
-  priseList: [Prise!]!
+  priseList: [Prise!]
 }
 
 extend type Mutation {

--- a/back/services/vaccine/src/schema/prise.graphql.ts
+++ b/back/services/vaccine/src/schema/prise.graphql.ts
@@ -16,7 +16,7 @@ export const PriseTypeDefs = gql`
   
   extend type Query {
     prise(id: ID!): Prise
-    priseList: [Prise!]!
+    priseList: [Prise!]
   }
 
   extend type Mutation {


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Allow `priseList` to return null by removing the outer non-null assertion on its return type in the GraphQL schema definitions.